### PR TITLE
Check that @config exists.  Fixes #413

### DIFF
--- a/lib/octopus/abstract_adapter.rb
+++ b/lib/octopus/abstract_adapter.rb
@@ -19,7 +19,7 @@ module Octopus
       end
 
       def octopus_shard
-        @config[:octopus_shard]
+        @config && @config[:octopus_shard]
       end
 
       def initialize(*args)


### PR DESCRIPTION
Error message is:

ActiveRecord::StatementInvalid: NoMethodError: undefined method `[]' for
nil:NilClass:

  from octopus/lib/octopus/abstract_adapter.rb:23:in `octopus_shard'
  from octopus/lib/octopus/abstract_adapter.rb:12:in `instrument'
  from vendor/bundle/ruby/2.3.0/gems/activerecord-4.2.11.1/lib/active_record/connection_adapters/abstract_adapter.rb:478:in `log'

This has shown to surface in the ibm_db and sqlserver adapters.